### PR TITLE
Fixes the SDXL pipeline loading from single file

### DIFF
--- a/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
+++ b/src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py
@@ -1286,11 +1286,10 @@ def download_from_original_stable_diffusion_ckpt(
             image_size = 512
 
     if controlnet is None:
-        controlnet = "control_stage_config" in original_config.model.params
-
-        controlnet = convert_controlnet_checkpoint(
-            checkpoint, original_config, checkpoint_path, image_size, upcast_attention, extract_ema
-        )
+        if "control_stage_config" in original_config.model.params.keys():
+            controlnet = convert_controlnet_checkpoint(
+                checkpoint, original_config, checkpoint_path, image_size, upcast_attention, extract_ema
+            )
 
     num_train_timesteps = getattr(original_config.model.params, "timesteps", None) or 1000
 


### PR DESCRIPTION
# What does this PR do?

Allows using `from_single_file` by `StableDiffusionXLPipeline`.

Original config of SDXL 0.9 model does not define a section for `controlnet`, but the script assumes it is. I believe it was [a recent typo](src/diffusers/pipelines/stable_diffusion/convert_from_ckpt.py), as it assigns a variable with the boolean expression result, and then instantly overrides it with load attempt, ignoring the boolean. Loading `controlnet` without config fails.

Fixes # (issue)
Unable to find the exact issue. Didn't create it myself.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/diffusers/blob/main/CONTRIBUTING.md)?
- [x] Did you read our [philosophy doc](https://github.com/huggingface/diffusers/blob/main/PHILOSOPHY.md) (important for complex PRs)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/diffusers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@patrickvonplaten
@sayakpaul
@williamberman